### PR TITLE
Clean up unreleased changelog entries

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
         run: yarn build-storybook
 
       - name: Run visual tests
+        if: github.actor != 'dependabot[bot]'
         env:
           HTML2IMG_RENDER_URL: ${{ secrets.HTML2IMG_RENDER_URL }}
           HTML2IMG_API_KEY: ${{ secrets.HTML2IMG_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 ## [`main`](https://github.com/walterra/react-milestones-vis/tree/main)
 
-- Updated `d3-milestones` to `v2.0.0`.
-- Added React 19 support and set the supported React range to 18.3–19.
-- Updated the test matrix to React 18.3 and React 19.2.
-- Updated the Node.js requirement to `22.18`.
-- Updated `d3-milestones` to `v1.5.0`.
 - Added support for `renderCallback`.
 - Added support for ordinal scales as an alternative to time scales.
 - Added `yarn build:examples` script to generate self-contained HTML examples.


### PR DESCRIPTION
## Summary

- remove release notes already covered by the 1.0.0 changeset
- remove the stale d3-milestones 1.5 upgrade entry
- retain the previously unreleased `renderCallback`, ordinal scale, and example-build entries

## Context

This prevents the generated 1.0.0 release notes from containing duplicate or contradictory upgrade entries. After merge, the Changesets release PR should update automatically.
