### PR TITLE
Add missing d3-milestones v2 mapping keys

### DIFF
--- a/.changeset/bright-maps-style.md
+++ b/.changeset/bright-maps-style.md
@@ -1,0 +1,5 @@
+---
+'react-milestones-vis': minor
+---
+
+Add support for custom IDs, category styles, and bullet styles in milestone mappings.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,29 @@ export const ProjectSteps = () => <Milestones
 
 `react-milestones-vis` is based on the d3 based library `d3-milestones`: https://github.com/walterra/d3-milestones
 
+## Data mapping
+
+The `mapping` prop maps milestone properties to fields in each data object. In addition to `timestamp`, `value`, `text`, `url`, `category`, and `entries`, it supports custom DOM IDs and inline style objects:
+
+```tsx
+<Milestones
+  data={[{
+    date: '2024-01-01',
+    label: 'Version 1.0',
+    elementId: 'version-1',
+    bulletCss: { backgroundColor: 'royalblue', borderColor: 'navy' },
+  }]}
+  mapping={{
+    timestamp: 'date',
+    text: 'label',
+    id: 'elementId',
+    bulletStyle: 'bulletCss',
+  }}
+/>
+```
+
+Use `categoryStyle` for style objects on category records. All supported mapping keys are `category`, `entries`, `timestamp`, `value`, `text`, `url`, `id`, `textStyle`, `titleStyle`, `categoryStyle`, and `bulletStyle`.
+
 ## Label distribution
 
 The `distribution` prop accepts the presets `top-bottom`, `top`, and `bottom`. It also supports data-driven object and function forms.

--- a/src/components/milestones/__unit_tests__/mapping.test.tsx
+++ b/src/components/milestones/__unit_tests__/mapping.test.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { Milestones } from '../milestones';
+
+const event = {
+  year: 2024,
+  title: 'Custom milestone',
+  customId: 'custom-milestone',
+  customBulletStyle: {
+    'background-color': 'rgb(255, 0, 0)',
+    'border-color': 'rgb(0, 0, 0)',
+  },
+};
+
+const baseMapping = {
+  timestamp: 'year',
+  text: 'title',
+};
+
+describe('Milestones Component - Mapping', () => {
+  test('maps a custom ID', () => {
+    const { container } = render(
+      <Milestones
+        data={[event]}
+        mapping={{ ...baseMapping, id: 'customId' }}
+        parseTime="%Y"
+      />
+    );
+
+    expect(container.querySelector('#custom-milestone')).toHaveTextContent(
+      'Custom milestone'
+    );
+  });
+
+  test('maps custom category styles', () => {
+    const data = [
+      {
+        name: 'Releases',
+        events: [event],
+        customCategoryStyle: {
+          color: 'rgb(0, 0, 255)',
+          'font-weight': '700',
+        },
+      },
+    ];
+    const { container } = render(
+      <Milestones
+        data={data}
+        mapping={{
+          ...baseMapping,
+          category: 'name',
+          entries: 'events',
+          categoryStyle: 'customCategoryStyle',
+        }}
+        parseTime="%Y"
+      />
+    );
+
+    const category = container.querySelector<HTMLElement>(
+      '.milestones__category_label'
+    );
+    expect(category).toHaveStyle({ color: 'rgb(0, 0, 255)', fontWeight: '700' });
+  });
+
+  test('maps custom bullet styles', () => {
+    const { container } = render(
+      <Milestones
+        data={[event]}
+        mapping={{ ...baseMapping, bulletStyle: 'customBulletStyle' }}
+        parseTime="%Y"
+      />
+    );
+
+    const bullet = container.querySelector<HTMLElement>(
+      '.milestones__group__bullet'
+    );
+    expect(bullet).toHaveStyle({
+      backgroundColor: 'rgb(255, 0, 0)',
+      borderColor: 'rgb(0, 0, 0)',
+    });
+  });
+
+  test('maps custom IDs, category styles, and bullet styles together', () => {
+    const data = [
+      {
+        name: 'Releases',
+        events: [event],
+        customCategoryStyle: { color: 'rgb(0, 128, 0)' },
+      },
+    ];
+    const { container } = render(
+      <Milestones
+        data={data}
+        mapping={{
+          ...baseMapping,
+          category: 'name',
+          entries: 'events',
+          id: 'customId',
+          categoryStyle: 'customCategoryStyle',
+          bulletStyle: 'customBulletStyle',
+        }}
+        parseTime="%Y"
+      />
+    );
+
+    expect(container.querySelector('#custom-milestone')).toBeInTheDocument();
+    expect(container.querySelector('.milestones__category_label')).toHaveStyle({
+      color: 'rgb(0, 128, 0)',
+    });
+    expect(container.querySelector('.milestones__group__bullet')).toHaveStyle({
+      backgroundColor: 'rgb(255, 0, 0)',
+    });
+  });
+});

--- a/src/components/milestones/index.ts
+++ b/src/components/milestones/index.ts
@@ -6,5 +6,6 @@ export type {
   MilestonesDistributionObject,
   MilestonesDistributionPreset,
   MilestonesDistributionValue,
+  MilestonesMapping,
   MilestonesOptions,
 } from './types';

--- a/src/components/milestones/types.ts
+++ b/src/components/milestones/types.ts
@@ -5,11 +5,16 @@ const milestonesMappingKeys = [
   'value',     // Used for ordinal scale
   'text',
   'url',
+  'id',
   'textStyle',
   'titleStyle',
+  'categoryStyle',
+  'bulletStyle',
 ] as const;
 type MilestonesMappingKeys = typeof milestonesMappingKeys[number];
-type MilestonesMapping = Record<MilestonesMappingKeys, string>;
+
+/** Maps milestone properties to fields in the supplied data. */
+export type MilestonesMapping = Record<MilestonesMappingKeys, string>;
 export const isPartialMapping = (
   arg: unknown
 ): arg is Partial<MilestonesMapping> =>

--- a/src/stories/milestones.stories.tsx
+++ b/src/stories/milestones.stories.tsx
@@ -121,6 +121,37 @@ export const Styles: Story = {
   },
 };
 
+export const CustomMappingFields: Story = {
+  render: (args) => <Milestones {...args} />,
+  args: {
+    aggregateBy: 'year',
+    parseTime: '%Y',
+    mapping: {
+      category: 'name',
+      entries: 'events',
+      timestamp: 'year',
+      text: 'title',
+      id: 'elementId',
+      categoryStyle: 'categoryCss',
+      bulletStyle: 'bulletCss',
+    },
+    data: [
+      {
+        name: 'Releases',
+        categoryCss: { color: 'royalblue', fontWeight: 'bold' },
+        events: [
+          {
+            year: 2024,
+            title: 'Version 1.0',
+            elementId: 'version-1',
+            bulletCss: { backgroundColor: 'royalblue', borderColor: 'navy' },
+          },
+        ],
+      },
+    ],
+  },
+};
+
 export const DeclarativeDistribution: Story = {
   render: (args) => <Milestones {...args} />,
   args: {


### PR DESCRIPTION
## Summary
- expose `id`, `categoryStyle`, and `bulletStyle` through the public mapping type and runtime guard
- add independent and combined DOM rendering coverage
- document the mapping fields and add a Storybook example

## Verification
- `yarn check:all`
- `yarn test:supported`
- `yarn build`

Closes #26