### PR TITLE
Type event callback payloads

### DIFF
--- a/.changeset/type-event-callback-payloads.md
+++ b/.changeset/type-event-callback-payloads.md
@@ -1,0 +1,5 @@
+---
+'react-milestones-vis': patch
+---
+
+Type label event callback payloads and preserve the component's source data generic in callback attributes.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,28 @@ Use a function for grouped or computed logic. It receives the grouped event data
 
 For vertical timelines, `top` means left and `bottom` means right.
 
+## Event callbacks
+
+`onEventClick`, `onEventMouseOver`, and `onEventMouseLeave` receive a `MilestonesEventPayload<T>`. The payload contains the mapped `text` and `timestamp` values plus the original source object in `attributes`:
+
+```tsx
+interface Release {
+  releasedAt: string;
+  title: string;
+  version: string;
+}
+
+<Milestones<Release>
+  data={releases}
+  mapping={{ timestamp: 'releasedAt', text: 'title' }}
+  onEventClick={({ text, timestamp, attributes }) => {
+    console.log(text, timestamp, attributes.version);
+  }}
+/>
+```
+
+The component generic (`Release` above) is preserved by `MilestonesEventPayload<Release>`, so callback code can access source-specific fields without casts. `timestamp` is `undefined` when no timestamp mapping applies, such as an ordinal timeline configured only with `value`.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/components/milestones/__unit_tests__/callbacks.test.tsx
+++ b/src/components/milestones/__unit_tests__/callbacks.test.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { Milestones } from '../milestones';
+import { MilestonesEventPayload } from '../types';
 import { vikingsData } from './test-utils';
 
 describe('Milestones Component - Callbacks', () => {
   test('calls renderCallback after rendering', async () => {
-    // Create a mock function for renderCallback
     const mockRenderCallback = jest.fn();
 
     render(
@@ -22,17 +22,17 @@ describe('Milestones Component - Callbacks', () => {
     );
 
     await waitFor(() => {
-      // Check if the callback was called
       expect(mockRenderCallback).toHaveBeenCalled();
     });
   });
 
-  test('calls onEventClick handler when provided', async () => {
-    // Create a mock function for onClick
-    const onEventClick = jest.fn();
+  test('passes mapped and source data to all event callbacks', async () => {
+    const onEventClick = jest.fn<void, [MilestonesEventPayload<typeof vikingsData[number]>]>();
+    const onEventMouseOver = jest.fn<void, [MilestonesEventPayload<typeof vikingsData[number]>]>();
+    const onEventMouseLeave = jest.fn<void, [MilestonesEventPayload<typeof vikingsData[number]>]>();
 
     const { container } = render(
-      <Milestones
+      <Milestones<typeof vikingsData[number]>
         data={vikingsData}
         aggregateBy="year"
         mapping={{
@@ -41,21 +41,32 @@ describe('Milestones Component - Callbacks', () => {
         }}
         parseTime="%Y"
         onEventClick={onEventClick}
+        onEventMouseOver={onEventMouseOver}
+        onEventMouseLeave={onEventMouseLeave}
       />
     );
 
-    // Wait for rendering to complete
-    await waitFor(() => {
-      expect(container.querySelector('.milestones')).toBeInTheDocument();
+    const label = await waitFor(() => {
+      const renderedLabel = container.querySelector('.milestones-label');
+      expect(renderedLabel).toBeInTheDocument();
+      return renderedLabel as Element;
     });
+    const expectedPayload = {
+      text: vikingsData[0].title,
+      timestamp: vikingsData[0].year,
+      attributes: vikingsData[0],
+    };
 
-    // Note: We can't trigger click events in this test because d3-milestones
-    // handles them internally, but we can verify the component rendered with the prop
-    expect(container.firstChild).toBeInTheDocument();
+    fireEvent.click(label);
+    fireEvent.mouseOver(label);
+    fireEvent.mouseLeave(label);
+
+    expect(onEventClick).toHaveBeenCalledWith(expectedPayload);
+    expect(onEventMouseOver).toHaveBeenCalledWith(expectedPayload);
+    expect(onEventMouseLeave).toHaveBeenCalledWith(expectedPayload);
   });
 
   test('calls renderCallback after component updates', async () => {
-    // Create a mock function for the update callback
     const mockRenderCallback = jest.fn();
 
     const { rerender } = render(
@@ -72,14 +83,11 @@ describe('Milestones Component - Callbacks', () => {
     );
 
     await waitFor(() => {
-      // Check if the callback was called at least once
       expect(mockRenderCallback).toHaveBeenCalled();
     });
 
-    // Reset the mock to clearly see new calls
     mockRenderCallback.mockClear();
 
-    // Update with new data
     const newData = [
       ...vikingsData,
       {
@@ -88,7 +96,6 @@ describe('Milestones Component - Callbacks', () => {
       },
     ];
 
-    // Rerender with new data
     rerender(
       <Milestones
         data={newData}
@@ -102,9 +109,7 @@ describe('Milestones Component - Callbacks', () => {
       />
     );
 
-    // Wait for re-rendering to complete
     await waitFor(() => {
-      // Check if the callback was called after update
       expect(mockRenderCallback).toHaveBeenCalled();
     });
   });

--- a/src/components/milestones/__unit_tests__/callbacks.test.tsx
+++ b/src/components/milestones/__unit_tests__/callbacks.test.tsx
@@ -6,6 +6,7 @@ import { vikingsData } from './test-utils';
 
 describe('Milestones Component - Callbacks', () => {
   test('calls renderCallback after rendering', async () => {
+    // Create a mock function for renderCallback
     const mockRenderCallback = jest.fn();
 
     render(
@@ -22,6 +23,7 @@ describe('Milestones Component - Callbacks', () => {
     );
 
     await waitFor(() => {
+      // Check if the callback was called
       expect(mockRenderCallback).toHaveBeenCalled();
     });
   });
@@ -46,6 +48,7 @@ describe('Milestones Component - Callbacks', () => {
       />
     );
 
+    // Wait for d3-milestones to render and bind events to a label.
     const label = await waitFor(() => {
       const renderedLabel = container.querySelector('.milestones-label');
       expect(renderedLabel).toBeInTheDocument();
@@ -67,6 +70,7 @@ describe('Milestones Component - Callbacks', () => {
   });
 
   test('calls renderCallback after component updates', async () => {
+    // Create a mock function for the update callback
     const mockRenderCallback = jest.fn();
 
     const { rerender } = render(
@@ -83,11 +87,14 @@ describe('Milestones Component - Callbacks', () => {
     );
 
     await waitFor(() => {
+      // Check if the callback was called at least once
       expect(mockRenderCallback).toHaveBeenCalled();
     });
 
+    // Reset the mock to clearly see new calls
     mockRenderCallback.mockClear();
 
+    // Update with new data
     const newData = [
       ...vikingsData,
       {
@@ -96,6 +103,7 @@ describe('Milestones Component - Callbacks', () => {
       },
     ];
 
+    // Rerender with new data
     rerender(
       <Milestones
         data={newData}
@@ -109,7 +117,9 @@ describe('Milestones Component - Callbacks', () => {
       />
     );
 
+    // Wait for re-rendering to complete
     await waitFor(() => {
+      // Check if the callback was called after update
       expect(mockRenderCallback).toHaveBeenCalled();
     });
   });

--- a/src/components/milestones/index.ts
+++ b/src/components/milestones/index.ts
@@ -6,6 +6,7 @@ export type {
   MilestonesDistributionObject,
   MilestonesDistributionPreset,
   MilestonesDistributionValue,
+  MilestonesEventPayload,
   MilestonesMapping,
   MilestonesOptions,
 } from './types';

--- a/src/components/milestones/milestones.tsx
+++ b/src/components/milestones/milestones.tsx
@@ -14,8 +14,25 @@ import {
   isRange,
   isScaleType,
   isUrlTarget,
+  MilestonesEventPayload,
   MilestonesOptions,
 } from './types';
+
+interface D3MilestonesEventTarget extends EventTarget {
+  __data__: MilestonesEventPayload<unknown>;
+}
+
+const eventPayloadCallback = <T,>(
+  callback: (event: MilestonesEventPayload<T>) => void
+): ((eventOrPayload: unknown) => void) => (eventOrPayload): void => {
+  if (eventOrPayload instanceof Event) {
+    const target = eventOrPayload.currentTarget as D3MilestonesEventTarget;
+    callback(target.__data__ as MilestonesEventPayload<T>);
+    return;
+  }
+
+  callback(eventOrPayload as MilestonesEventPayload<T>);
+};
 
 interface IMilestones<T> {
   aggregateBy: (d: MilestonesOptions<T>['aggregateBy']) => IMilestones<T>;
@@ -30,9 +47,9 @@ interface IMilestones<T> {
   urlTarget: (d: MilestonesOptions<T>['urlTarget']) => IMilestones<T>;
   useLabels: (d: MilestonesOptions<T>['useLabels']) => IMilestones<T>;
   range: (d: MilestonesOptions<T>['range']) => IMilestones<T>;
-  onEventClick: (d: MilestonesOptions<T>['onEventClick']) => IMilestones<T>;
-  onEventMouseLeave: (d: MilestonesOptions<T>['onEventMouseLeave']) => IMilestones<T>;
-  onEventMouseOver: (d: MilestonesOptions<T>['onEventMouseOver']) => IMilestones<T>;
+  onEventClick: (d: (event: unknown) => void) => IMilestones<T>;
+  onEventMouseLeave: (d: (event: unknown) => void) => IMilestones<T>;
+  onEventMouseOver: (d: (event: unknown) => void) => IMilestones<T>;
   renderCallback: (d: MilestonesOptions<T>['renderCallback']) => IMilestones<T>;
   render: (d: T[]) => void;
 }
@@ -85,11 +102,12 @@ export const Milestones = <T,>(props: MilestonesOptions<T>): ReactElement => {
       isUrlTarget(urlTarget) && vis.urlTarget(urlTarget);
       typeof useLabels === 'boolean' && vis.useLabels(useLabels);
       isRange(range) && vis.range(range);
-      typeof onEventClick === 'function' && vis.onEventClick(onEventClick);
+      typeof onEventClick === 'function' &&
+        vis.onEventClick(eventPayloadCallback(onEventClick));
       typeof onEventMouseLeave === 'function' &&
-        vis.onEventMouseLeave(onEventMouseLeave);
+        vis.onEventMouseLeave(eventPayloadCallback(onEventMouseLeave));
       typeof onEventMouseOver === 'function' &&
-        vis.onEventMouseOver(onEventMouseOver);
+        vis.onEventMouseOver(eventPayloadCallback(onEventMouseOver));
       typeof renderCallback === 'function' &&
         vis.renderCallback(renderCallback);
 

--- a/src/components/milestones/types.ts
+++ b/src/components/milestones/types.ts
@@ -123,6 +123,18 @@ type MilestonesScaleType = typeof milestonesScaleType[number];
 export const isScaleType = (arg: unknown): arg is MilestonesScaleType =>
   milestonesScaleType.includes(arg as MilestonesScaleType);
 
+/**
+ * Data passed to milestone label event callbacks.
+ *
+ * `text` and `timestamp` are the values selected by the configured mapping,
+ * while `attributes` contains the original source data object.
+ */
+export interface MilestonesEventPayload<T = unknown> {
+  text: string;
+  timestamp: string | number | Date | undefined;
+  attributes: T;
+}
+
 export interface MilestonesOptions<T = unknown> {
   /**
    * Aggregation level of time.
@@ -177,17 +189,20 @@ export interface MilestonesOptions<T = unknown> {
    */
   data: Array<T>;
   /**
-   * Optional label click handler
+   * Optional label click handler. Receives the mapped event values and the
+   * original source data object.
    */
-  onEventClick?: () => void;
+  onEventClick?: (event: MilestonesEventPayload<T>) => void;
   /**
-   * Optional label leave handler
+   * Optional label leave handler. Receives the mapped event values and the
+   * original source data object.
    */
-  onEventMouseLeave?: () => void;
+  onEventMouseLeave?: (event: MilestonesEventPayload<T>) => void;
   /**
-   * Optional label over handler
+   * Optional label over handler. Receives the mapped event values and the
+   * original source data object.
    */
-  onEventMouseOver?: () => void;
+  onEventMouseOver?: (event: MilestonesEventPayload<T>) => void;
   /**
    * Callback that executes after rendering is complete
    */


### PR DESCRIPTION
## Summary
- export a generic `MilestonesEventPayload<T>` for label callbacks
- normalize d3-milestones DOM events to their attached milestone data
- type and document click, mouse-over, and mouse-leave callback arguments
- add React 18 and React 19 callback payload coverage

## Verification
- `yarn typecheck`
- `yarn lint`
- `yarn test:supported`
- `yarn build`

Closes #28