### PR TITLE
Remove broken SSR test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "test:react19": "jest --config jest.config.js --selectProjects=react-19",
     "test:visual": "jest --config jest.config.js --selectProjects=visual-snapshots",
     "test:visual:update": "jest --config jest.config.js --selectProjects=visual-snapshots --updateSnapshot",
-    "test:react-ssr": "node scripts/test-react-ssr.js",
     "test:package": "yarn build && node scripts/test-package-content.js",
     "storybook": "storybook dev -p 6006",
     "deploy-storybook": "gh-pages -d storybook-static",


### PR DESCRIPTION
## Summary

- remove the stale `test:react-ssr` package command
- avoid advertising a script whose implementation was removed during the visual-test cleanup

## Context

The historical script was an HTML-to-image integration helper, not an SSR/package-import smoke test. It was never wired into CI or release verification, and restoring it would reintroduce obsolete functionality.

## Validation

- `package.json` parses successfully
- `git diff --check` passes

Closes #29