### PR TITLE
Replace handwritten d3-milestones interface with tested declarations

### DIFF
--- a/.changeset/typed-d3-milestones-adapter.md
+++ b/.changeset/typed-d3-milestones-adapter.md
@@ -1,0 +1,5 @@
+---
+'react-milestones-vis': patch
+---
+
+Replace the suppressed `d3-milestones` import and handwritten wrapper interface with tested declarations for the v2 adapter contract.

--- a/src/components/milestones/__type_tests__/d3-milestones-contract.ts
+++ b/src/components/milestones/__type_tests__/d3-milestones-contract.ts
@@ -1,0 +1,75 @@
+import milestones from 'd3-milestones';
+
+import type { D3MilestonesAdapter } from '../d3-milestones-adapter';
+
+interface Datum {
+  timestamp: string;
+  text: string;
+  lane: 'top' | 'bottom';
+}
+
+type AdapterMethods =
+  | 'aggregateBy'
+  | 'mapping'
+  | 'optimize'
+  | 'autoResize'
+  | 'orientation'
+  | 'distribution'
+  | 'scaleType'
+  | 'parseTime'
+  | 'labelFormat'
+  | 'urlTarget'
+  | 'useLabels'
+  | 'range'
+  | 'onEventClick'
+  | 'onEventMouseLeave'
+  | 'onEventMouseOver'
+  | 'renderCallback'
+  | 'render';
+
+type Equal<Left, Right> =
+  (<T>() => T extends Left ? 1 : 2) extends
+  (<T>() => T extends Right ? 1 : 2)
+    ? true
+    : false;
+type Assert<Condition extends true> = Condition;
+type AdapterContainsExactlyWrapperMethods = Assert<
+  Equal<keyof D3MilestonesAdapter<Datum>, AdapterMethods>
+>;
+
+declare const element: HTMLDivElement;
+const adapter = milestones<Datum>(element);
+const selectorAdapter = milestones<Datum>('#timeline');
+
+const chained: D3MilestonesAdapter<Datum> = adapter
+  .aggregateBy('day')
+  .mapping({ timestamp: 'timestamp', text: 'text' })
+  .optimize(true)
+  .autoResize(false)
+  .orientation('horizontal')
+  .distribution({ field: 'lane', top: 'top', bottom: 'bottom' })
+  .distribution((group, index) => group.values[index]?.lane === 'top')
+  .scaleType('time')
+  .parseTime('%Y-%m-%d')
+  .labelFormat('%Y')
+  .urlTarget('_blank')
+  .useLabels(true)
+  .range([0, 1])
+  .onEventClick((event) => event.currentTarget)
+  .onEventMouseLeave((event) => event.type)
+  .onEventMouseOver((event) => event.target)
+  .renderCallback(() => undefined)
+  .render([{ timestamp: '2026-01-01', text: 'Release', lane: 'top' }]);
+
+void chained;
+void selectorAdapter;
+void (undefined as unknown as AdapterContainsExactlyWrapperMethods);
+
+// @ts-expect-error Distribution objects require both top and bottom mappings.
+adapter.distribution({ field: 'lane', top: 'top' });
+// @ts-expect-error Render data must retain the adapter's datum type.
+adapter.render([{ timestamp: '2026-01-01', text: 'Release' }]);
+// @ts-expect-error d3 v3 listeners pass DOM events to adapter callbacks.
+adapter.onEventClick((event) => event.attributes);
+// @ts-expect-error The factory accepts selectors, not arbitrary values.
+milestones<Datum>(42);

--- a/src/components/milestones/d3-milestones-adapter.ts
+++ b/src/components/milestones/d3-milestones-adapter.ts
@@ -1,0 +1,83 @@
+/** Aggregation units accepted by d3-milestones v2. */
+export type D3MilestonesAggregateBy =
+  | 'second'
+  | 'minute'
+  | 'hour'
+  | 'day'
+  | 'week'
+  | 'month'
+  | 'quarter'
+  | 'year';
+
+export type D3MilestonesOrientation = 'horizontal' | 'vertical';
+export type D3MilestonesScaleType = 'time' | 'ordinal';
+export type D3MilestonesUrlTarget = '_blank' | '_self' | '_parent' | '_top';
+export type D3MilestonesRange = [number, number];
+
+export interface D3MilestonesMapping {
+  category: string;
+  entries: string;
+  timestamp: string;
+  value: string;
+  text: string;
+  url: string;
+  id: string;
+  textStyle: string;
+  titleStyle: string;
+  categoryStyle: string;
+  bulletStyle: string;
+}
+
+export type D3MilestonesDistributionPreset = 'top-bottom' | 'top' | 'bottom';
+export type D3MilestonesDistributionValue = string | number | boolean | null;
+
+export interface D3MilestonesDistributionObject {
+  field: string;
+  top: D3MilestonesDistributionValue | D3MilestonesDistributionValue[];
+  bottom: D3MilestonesDistributionValue | D3MilestonesDistributionValue[];
+}
+
+export interface D3MilestonesDistributionData<T = unknown> {
+  key?: string;
+  values: T[];
+  index?: number;
+  timelineIndex?: number;
+  scaleType?: D3MilestonesScaleType;
+}
+
+export type D3MilestonesDistributionFunction<T = unknown> = (
+  data: D3MilestonesDistributionData<T>,
+  index: number
+) => boolean;
+
+export type D3MilestonesDistribution<T = unknown> =
+  | D3MilestonesDistributionPreset
+  | D3MilestonesDistributionObject
+  | D3MilestonesDistributionFunction<T>;
+
+export interface D3MilestonesEventPayload<T = unknown> {
+  text: string;
+  timestamp: string | number | Date | undefined;
+  attributes: T;
+}
+
+/** Chainable subset of the d3-milestones v2 API used by the React wrapper. */
+export interface D3MilestonesAdapter<T = unknown> {
+  aggregateBy(value: D3MilestonesAggregateBy): D3MilestonesAdapter<T>;
+  mapping(value: Partial<D3MilestonesMapping>): D3MilestonesAdapter<T>;
+  optimize(value: boolean): D3MilestonesAdapter<T>;
+  autoResize(value: boolean): D3MilestonesAdapter<T>;
+  orientation(value: D3MilestonesOrientation): D3MilestonesAdapter<T>;
+  distribution(value: D3MilestonesDistribution<T>): D3MilestonesAdapter<T>;
+  scaleType(value: D3MilestonesScaleType): D3MilestonesAdapter<T>;
+  parseTime(value: string): D3MilestonesAdapter<T>;
+  labelFormat(value: string): D3MilestonesAdapter<T>;
+  urlTarget(value: D3MilestonesUrlTarget): D3MilestonesAdapter<T>;
+  useLabels(value: boolean): D3MilestonesAdapter<T>;
+  range(value: D3MilestonesRange): D3MilestonesAdapter<T>;
+  onEventClick(callback: (event: Event) => void): D3MilestonesAdapter<T>;
+  onEventMouseLeave(callback: (event: Event) => void): D3MilestonesAdapter<T>;
+  onEventMouseOver(callback: (event: Event) => void): D3MilestonesAdapter<T>;
+  renderCallback(callback: () => void): D3MilestonesAdapter<T>;
+  render(data: T[]): D3MilestonesAdapter<T>;
+}

--- a/src/components/milestones/milestones.tsx
+++ b/src/components/milestones/milestones.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement, useEffect, useRef, useState } from 'react';
 
-// @ts-ignore Could not find a declaration file for module 'd3-milestones'.
 import milestones from 'd3-milestones';
 
 import '../../../node_modules/d3-milestones/build/d3-milestones.css';
 
+import type { D3MilestonesAdapter } from './d3-milestones-adapter';
 import { getDefaults } from './defaults';
 import {
   isAggregateBy,
@@ -24,46 +24,21 @@ interface D3MilestonesEventTarget extends EventTarget {
 
 const eventPayloadCallback = <T,>(
   callback: (event: MilestonesEventPayload<T>) => void
-): ((eventOrPayload: unknown) => void) => (eventOrPayload): void => {
-  if (eventOrPayload instanceof Event) {
-    const target = eventOrPayload.currentTarget as D3MilestonesEventTarget;
-    callback(target.__data__ as MilestonesEventPayload<T>);
-    return;
-  }
-
-  callback(eventOrPayload as MilestonesEventPayload<T>);
+): ((event: Event) => void) => (event): void => {
+  const target = event.currentTarget as D3MilestonesEventTarget;
+  callback(target.__data__ as MilestonesEventPayload<T>);
 };
-
-interface IMilestones<T> {
-  aggregateBy: (d: MilestonesOptions<T>['aggregateBy']) => IMilestones<T>;
-  mapping: (d: MilestonesOptions<T>['mapping']) => IMilestones<T>;
-  optimize: (d: MilestonesOptions<T>['optimize']) => IMilestones<T>;
-  autoResize: (d: MilestonesOptions<T>['autoResize']) => IMilestones<T>;
-  orientation: (d: MilestonesOptions<T>['orientation']) => IMilestones<T>;
-  distribution: (d: MilestonesOptions<T>['distribution']) => IMilestones<T>;
-  scaleType: (d: MilestonesOptions<T>['scaleType']) => IMilestones<T>;
-  parseTime: (d: MilestonesOptions<T>['parseTime']) => IMilestones<T>;
-  labelFormat: (d: MilestonesOptions<T>['labelFormat']) => IMilestones<T>;
-  urlTarget: (d: MilestonesOptions<T>['urlTarget']) => IMilestones<T>;
-  useLabels: (d: MilestonesOptions<T>['useLabels']) => IMilestones<T>;
-  range: (d: MilestonesOptions<T>['range']) => IMilestones<T>;
-  onEventClick: (d: (event: unknown) => void) => IMilestones<T>;
-  onEventMouseLeave: (d: (event: unknown) => void) => IMilestones<T>;
-  onEventMouseOver: (d: (event: unknown) => void) => IMilestones<T>;
-  renderCallback: (d: MilestonesOptions<T>['renderCallback']) => IMilestones<T>;
-  render: (d: T[]) => void;
-}
 
 /**
  * React Milestones Visualization
  */
 export const Milestones = <T,>(props: MilestonesOptions<T>): ReactElement => {
   const milestonesDivEl = useRef<HTMLDivElement>(null);
-  const [vis, setVis] = useState<IMilestones<T>>();
+  const [vis, setVis] = useState<D3MilestonesAdapter<T>>();
 
   useEffect(() => {
     if (milestonesDivEl.current !== null) {
-      setVis(milestones(milestonesDivEl.current) as IMilestones<T>);
+      setVis(milestones<T>(milestonesDivEl.current));
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [milestonesDivEl.current]);

--- a/src/components/milestones/types.ts
+++ b/src/components/milestones/types.ts
@@ -1,3 +1,15 @@
+import type {
+  D3MilestonesAdapter,
+  D3MilestonesDistribution,
+  D3MilestonesDistributionData,
+  D3MilestonesDistributionFunction,
+  D3MilestonesDistributionObject,
+  D3MilestonesDistributionPreset,
+  D3MilestonesDistributionValue,
+  D3MilestonesEventPayload,
+  D3MilestonesMapping,
+} from './d3-milestones-adapter';
+
 const milestonesMappingKeys = [
   'category',
   'entries',
@@ -14,7 +26,7 @@ const milestonesMappingKeys = [
 type MilestonesMappingKeys = typeof milestonesMappingKeys[number];
 
 /** Maps milestone properties to fields in the supplied data. */
-export type MilestonesMapping = Record<MilestonesMappingKeys, string>;
+export type MilestonesMapping = D3MilestonesMapping;
 export const isPartialMapping = (
   arg: unknown
 ): arg is Partial<MilestonesMapping> =>
@@ -45,32 +57,22 @@ export const isOrientation = (arg: unknown): arg is MilestonesOrientation =>
   milestonesOrientation.includes(arg as MilestonesOrientation);
 
 const milestonesDistribution = ['top-bottom', 'top', 'bottom'] as const;
-export type MilestonesDistributionPreset = typeof milestonesDistribution[number];
-export type MilestonesDistributionValue = string | number | boolean | null;
+export type MilestonesDistributionPreset = D3MilestonesDistributionPreset;
+export type MilestonesDistributionValue = D3MilestonesDistributionValue;
 
 /** Declarative field-based label distribution. */
-export interface MilestonesDistributionObject {
-  field: string;
-  top: MilestonesDistributionValue | MilestonesDistributionValue[];
-  bottom: MilestonesDistributionValue | MilestonesDistributionValue[];
-}
+export type MilestonesDistributionObject = D3MilestonesDistributionObject;
 
 /** Grouped event data passed to a custom distribution function. */
-export interface MilestonesDistributionData<T = unknown> {
-  values: T[];
-  [key: string]: unknown;
-}
+export type MilestonesDistributionData<T = unknown> =
+  D3MilestonesDistributionData<T>;
 
 /** Custom label distribution function. `true` places a group above the timeline. */
-export type MilestonesDistributionFunction<T = unknown> = (
-  data: MilestonesDistributionData<T>,
-  index: number
-) => boolean;
+export type MilestonesDistributionFunction<T = unknown> =
+  D3MilestonesDistributionFunction<T>;
 
 export type MilestonesDistribution<T = unknown> =
-  | MilestonesDistributionPreset
-  | MilestonesDistributionObject
-  | MilestonesDistributionFunction<T>;
+  D3MilestonesDistribution<T>;
 
 const isDistributionValue = (arg: unknown): arg is MilestonesDistributionValue =>
   arg === null || ['string', 'number', 'boolean'].includes(typeof arg);
@@ -129,61 +131,58 @@ export const isScaleType = (arg: unknown): arg is MilestonesScaleType =>
  * `text` and `timestamp` are the values selected by the configured mapping,
  * while `attributes` contains the original source data object.
  */
-export interface MilestonesEventPayload<T = unknown> {
-  text: string;
-  timestamp: string | number | Date | undefined;
-  attributes: T;
-}
+export type MilestonesEventPayload<T = unknown> =
+  D3MilestonesEventPayload<T>;
 
 export interface MilestonesOptions<T = unknown> {
   /**
    * Aggregation level of time.
    */
-  aggregateBy?: MilestonesAggregateBy;
+  aggregateBy?: Parameters<D3MilestonesAdapter<T>['aggregateBy']>[0];
   /**
    * Map attributes to timestamp/value and text.
    */
-  mapping?: Partial<MilestonesMapping>;
+  mapping?: Parameters<D3MilestonesAdapter<T>['mapping']>[0];
   /**
    * Enable/disable label overlap removal.
    */
-  optimize?: boolean;
+  optimize?: Parameters<D3MilestonesAdapter<T>['optimize']>[0];
   /**
    * Enable/disable automatic resizing.
    */
-  autoResize?: boolean;
+  autoResize?: Parameters<D3MilestonesAdapter<T>['autoResize']>[0];
   /**
    * Layout orientation, `horizontal` (default) and `vertical` are available.
    */
-  orientation?: MilestonesOrientation;
+  orientation?: Parameters<D3MilestonesAdapter<T>['orientation']>[0];
   /**
    * Label distribution preset, declarative field mapping, or custom function.
    */
-  distribution?: MilestonesDistribution<T>;
+  distribution?: Parameters<D3MilestonesAdapter<T>['distribution']>[0];
   /**
    * Scale type, `time` (default) or `ordinal` are available.
    */
-  scaleType?: MilestonesScaleType;
+  scaleType?: Parameters<D3MilestonesAdapter<T>['scaleType']>[0];
   /**
    * Custom time parser.
    */
-  parseTime?: string;
+  parseTime?: Parameters<D3MilestonesAdapter<T>['parseTime']>[0];
   /**
    * Custom label format.
    */
-  labelFormat?: string;
+  labelFormat?: Parameters<D3MilestonesAdapter<T>['labelFormat']>[0];
   /**
    * Target attribute for URLs.
    */
-  urlTarget?: MilestonesUrlTarget;
+  urlTarget?: Parameters<D3MilestonesAdapter<T>['urlTarget']>[0];
   /**
    * Enable/disable label display.
    */
-  useLabels?: boolean;
+  useLabels?: Parameters<D3MilestonesAdapter<T>['useLabels']>[0];
   /**
    * Custom date range for the timeline. Useful to extend bounds beyound the dataset.
    */
-  range?: MilestonesRange;
+  range?: Parameters<D3MilestonesAdapter<T>['range']>[0];
   /**
    * Array of data elements.
    */
@@ -206,5 +205,5 @@ export interface MilestonesOptions<T = unknown> {
   /**
    * Callback that executes after rendering is complete
    */
-  renderCallback?: () => void;
+  renderCallback?: Parameters<D3MilestonesAdapter<T>['renderCallback']>[0];
 }

--- a/src/d3-milestones.d.ts
+++ b/src/d3-milestones.d.ts
@@ -1,0 +1,5 @@
+declare module 'd3-milestones' {
+  export default function milestones<T = unknown>(
+    selector: string | Element
+  ): import('./components/milestones/d3-milestones-adapter').D3MilestonesAdapter<T>;
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,11 +5,17 @@
     "declaration": true,
     "declarationDir": "./build"
   },
-  "include": ["src/index.ts", "src/components/**/*.ts", "src/components/**/*.tsx"],
+  "include": [
+    "src/index.ts",
+    "src/**/*.d.ts",
+    "src/components/**/*.ts",
+    "src/components/**/*.tsx"
+  ],
   "exclude": [
     "src/**/*.test.ts",
     "src/**/*.test.tsx",
     "src/**/__unit_tests__/**",
-    "src/**/__visual_tests__/**"
+    "src/**/__visual_tests__/**",
+    "src/**/__type_tests__/**"
   ]
 }


### PR DESCRIPTION
## Summary

- add declarations for the subset of the `d3-milestones@2.0.0` adapter used by the React wrapper
- remove the suppressed import and handwritten adapter interface
- derive wrapper option types from the adapter contract where applicable
- add compile-time contract tests for methods, chaining, callbacks, distribution, and render data

## Verification

- `yarn typecheck`
- `yarn lint`
- `yarn test:react19 --runInBand --testPathPattern='(callbacks|distribution)\\.test\\.tsx$'`
- `yarn build`

Closes #32
